### PR TITLE
updated README for default inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ cloud provider DNS and hostname settings.
 | ---- | -------- | ---- | ------ | ------- |
 | dns1 | t2.small | 1 | 2GiB | dns, haproxy |
 | clients1,2 | t2.small | 1 | 2GiB | demoapp, clients |
-| capsule1,2 | m5d.large | 2 | 8GiB | capsule |
-| satellite | m5d.xlarge | 4 | 16GiB | satellite |
+| capsule1,2 | m5.large | 2 | 8GiB | capsule |
+| satellite | m5.xlarge | 4 | 16GiB | satellite |
 
 ### Inventory Variables you'll probably need to change 
 


### PR DESCRIPTION
I ended up using m5.large instead of the m5d.large as for whatever
reason they only had 7.5 GiB instead of 8 GiB, and the installer was
angry. The m5.large really do have 8 GiB.

Also, the I/O on the m-series AWS instances are better than the t2 - or
at least they're more consistent when I ran some benchmarks.